### PR TITLE
Feat/add docker standard tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.swp
+*.tar
+hadolint.json
+Makefile
+cst-result.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,6 @@ RUN \
 ENTRYPOINT ["/usr/sbin/crond"]
 
 CMD ["-f", "-d", "8"]
+
+LABEL io.jenkins-infra.tools="crond"
+LABEL io.jenkins-infra.tools.crond.version="latest"

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,5 @@
-buildDockerAndPublishImage('crond', [mainBranch: 'main'])
+buildDockerAndPublishImage('crond', [
+  mainBranch: 'main',
+  automaticSemanticVersioning: true,
+  gitCredentials: 'github-app-infra'
+])

--- a/cst.yml
+++ b/cst.yml
@@ -1,0 +1,9 @@
+schemaVersion: 2.0.0
+metadataTest:
+  labels:
+    - key: io.jenkins-infra.tools
+      value: "crond"
+    - key: io.jenkins-infra.tools.crond.version
+      value: "latest"
+  entrypoint: ["/usr/sbin/crond"]
+  cmd:  ["-f", "-d", "8"]


### PR DESCRIPTION
- Automatic release
- Add a basic `cst.yml` (please note that existence of the file `/usr/sbin/crond` cannot be checked as it is a symlink)
- Add labels for our traceability system 