### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,17 +1,13 @@
----
 name: Release Drafter
-
 on:
   workflow_dispatch:
   push:
   release:
-
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
         env:
           # This token is generated automatically by default in GitHub Actions: no need to create it manually
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-...


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402